### PR TITLE
fix: end of content-range should be inclusive

### DIFF
--- a/blobd/src/endpoint/read_object.rs
+++ b/blobd/src/endpoint/read_object.rs
@@ -95,7 +95,7 @@ pub async fn endpoint_read_object(
         .header("content-length", (end - start).to_string())
         .header(
           "content-range",
-          format!("bytes {start}-{end}/{object_size}"),
+          format!("bytes {start}-{}/{object_size}", end.saturating_sub(1)),
         )
         .header("x-blobd-object-id", object_id.to_string())
         .body(StreamBody::new(data_stream.map(|chunk| {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Range:

```
<range>: A range with the format <range-start>-<range-end>, where
<range-start> and <range-end> are integers for the start and end position
(zero-indexed & inclusive) of the range in the given <unit>, respectively.
```