### PR TITLE
fix: set TCP nodelay on accepted connections

### DIFF
--- a/blobd/src/server.rs
+++ b/blobd/src/server.rs
@@ -53,6 +53,7 @@ pub async fn start_http_server_loop(interface: Ipv4Addr, port: u16, ctx: Arc<Htt
   info!(interface = interface.to_string(), port, "starting server");
 
   Server::bind(&addr)
+    .tcp_nodelay(true)
     .serve(app.into_make_service())
     .await
     .unwrap();


### PR DESCRIPTION
Get rid of unnecessary delays during request/response roundtrips.